### PR TITLE
imprv: set output's primary_key to (placeId, reviewId)

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -109,7 +109,7 @@ class Component(ComponentBase):
         Downloads items from `dataset_id` in batches and stores them in `output.csv` output table
     """
     def write_output_table(self, apify_client: ApifyClient, dataset_id: str):
-        output_table = self.create_out_table_definition('output.csv', incremental=True)
+        output_table = self.create_out_table_definition('output.csv', incremental=True, primary_key=['placeId', 'reviewId'])
         for col in OUTPUT_COLUMNS:
             output_table.add_column(col)
         self.write_manifest(output_table)


### PR DESCRIPTION
Closes #4 

output.csv.manifest:
```json
{"incremental": true, "primary_key": ["placeId", "reviewId"], "write_always": false, "delimiter": ",", "enclosure": "\""}
```