### PR TITLE
fix: skip items with error fields, and log the error

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -174,6 +174,11 @@ class Component(ComponentBase):
                 items_csv = dataset_client.download_items(offset=offset, limit=limit, item_format='csv').decode('utf-8-sig')
                 csv_reader = csv.DictReader(io.StringIO(items_csv))
                 for item in csv_reader:
+                    # NOTE: dataset items with `error` are skipped, we only log the `error`
+                    error = item.get('error')
+                    if error:
+                        logging.warning('Found item with error property, skipping it...Error: %s' % (item.get('errorDescription') or error))
+                        continue
                     row = {}
                     for col in dataset_fields:
                         row[col] = item.get(col)


### PR DESCRIPTION
> Regarding the new Google scraping component. I have just found out that the results from the scraper can have NULL values in the reviewId column, which is a PK. It happens because the errors are logged as a part of the table. Could you please change the component output mapping so that the errors are logged in the separate table? Those NULL values in PK column are creating duplicates and are a source of downstream pipeline issues.

https://apify.slack.com/archives/CCNL1CBFC/p1754413922066199