### PR TITLE
fix: AJDA-2973 pin keboola-component to >=1.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-keboola.component
+keboola.component>=1.11.0
 keboola.utils
 keboola.http-client
 freezegun


### PR DESCRIPTION
## Link to issue
https://linear.app/keboola/issue/AJDA-2973

## Description
Aligns this component with the `keboola-component` 1.11.0 update.

**`requirements.txt`: `keboola.component` (unpinned) → `>=1.11.0`.** Under `data_type_support=authoritative` the platform emits input table manifests carrying both a native `schema` node and the legacy `columns`/`metadata`/`column_metadata` keys. The library between ~1.6 and 1.11.0 rejected these with `UserException("Manifest can't contain new 'schema' and old 'metadata'/'column_metadata'/'columns'")` when reading input tables via `get_input_tables_definitions()`; 1.11.0 (AJDA-2973) removes that guard in `dao.load_table_metadata_from_manifest`, because the guard was invalid in the first place. Pinning `>=1.11.0` guarantees the fix regardless of build/pip caching.
