### PR TITLE
fix: AJDA-2973 set Apify integration headers via constructor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ keboola.http-client
 freezegun
 mock
 pydantic
-apify-client
+apify-client>=2.5.0

--- a/src/component.py
+++ b/src/component.py
@@ -6,7 +6,6 @@ import csv
 import io
 import logging
 from apify_client import ApifyClient
-import httpx
 
 from keboola.component.base import ComponentBase
 from keboola.component.exceptions import UserException
@@ -54,8 +53,7 @@ class Component(ComponentBase):
             "x-apify-integration-platform": "keboola",
             "x-apify-integration-app-id": "google-maps-reviews-scraper"
         }
-        apify_client = ApifyClient(token=params.token)
-        apify_client.http_client.httpx_client.headers.update(custom_headers)
+        apify_client = ApifyClient(token=params.token, headers=custom_headers)
         actor_client = apify_client.actor(ACTOR_ID)
 
         try:


### PR DESCRIPTION
## Link to issue

Follow-up to #26 (AJDA-2973).

## Description

After #26 merged, runs failed at startup with:

```
AttributeError: 'ImpitHttpClient' object has no attribute 'httpx_client'
  File "/code/src/component.py", line 58, in run
    apify_client.http_client.httpx_client.headers.update(custom_headers)
```

Root cause: `apify-client` was unpinned, so builds pulled in ≥ 2.0.0, which replaced the `httpx` HTTP backend with `impit` (`ImpitHttpClient`) and removed the `http_client.httpx_client` attribute the integration-header code reached for. The `keboola-component` pin in #26 didn't cause the break — it just triggered a rebuild that picked up the newer `apify-client`.

Fix: set the integration-tracking headers through the `ApifyClient(headers=...)` constructor argument (added in `apify-client` 2.5.0), which propagates them to the underlying `impit` client as default headers on every request. Removed the now-unused `httpx` import and pinned `apify-client>=2.5.0`.

## Justification

Restores the `x-apify-integration-*` tracking headers and unblocks the component, which currently crashes on every run.

## Plans for Customer Communication

None.

## Impact Analysis

Low. The header behavior is functionally identical to the original intent; only the mechanism changed. Verified against `apify-client` 3.0.6 that the old line reproduces the error and the `headers=` constructor path propagates the headers through `ImpitHttpClient` → `impit.Client`. Not feature-flagged.

## Deployment Plan

Standard CI/CD — image published from the merge commit, ArgoCD picks it up.

## Rollback Plan

Revert this PR, or roll back to the previous image tag in ArgoGitops.

## Post-Release Support Plan

None.