### PR TITLE
fix: AJDA-2973 read Apify Run/Dataset responses via attributes

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -65,14 +65,14 @@ class Component(ComponentBase):
         actor_run = actor_client.start(run_input = run_input)
         if not actor_run:
             raise UserException('Received empty run response. If the error keeps happening, contact Apify support: support@apify.com')
-        run_id = actor_run['id']
+        run_id = actor_run.id
         logging.info('Started Google Maps Reviews Scraper run. You can check the progress at https://console.apify.com/view/runs/%s' % run_id)
 
         run_client = apify_client.run(run_id)
         run_client.wait_for_finish()
         logging.info('Run has finished')
 
-        dataset_id = actor_run['defaultDatasetId']
+        dataset_id = actor_run.default_dataset_id
 
         self.write_output_table(apify_client, dataset_id)
 
@@ -149,7 +149,7 @@ class Component(ComponentBase):
 
         dataset_fields = self.prepare_dataset_fields(dataset_client)
 
-        item_count = dataset['itemCount']
+        item_count = dataset.item_count
         logging.info('Storing %d items from dataset (id: "%s") to CSV output table' % (item_count, dataset_id))
 
         limit = 2_000


### PR DESCRIPTION
## Link to issue

Follow-up to #27 (AJDA-2973) — continues the `apify-client` 2.x migration.

## Description

Runs failed with:

```
TypeError: 'Run' object is not subscriptable
  File "/code/src/component.py", line 68, in run
    run_id = actor_run['id']
```

Root cause: `apify-client` 2.0.0 changed API responses from plain dicts to Pydantic models. The component still read them with dict subscripting, which now raises `TypeError`. This is the same breaking change that #27 addressed for the HTTP client; these response accesses were the remaining dict-style usages.

Fix: read the fields as model attributes (snake_case) instead of dict keys:
- `actor_run['id']` → `actor_run.id`
- `actor_run['defaultDatasetId']` → `actor_run.default_dataset_id`
- `dataset['itemCount']` → `dataset.item_count`

`download_items()` still returns bytes and the CSV rows are plain dicts, so those `.get()` calls are unaffected.

## Justification

The component crashes on every run after start; this restores run/dataset handling under `apify-client >= 2.5.0` (already pinned in #27).

## Plans for Customer Communication

None.

## Impact Analysis

Low. Behavior is unchanged; only the field-access mechanism is corrected. Verified against `apify-client` 3.0.6 that the old subscripts reproduce the reported `TypeError` and that `.id` / `.default_dataset_id` / `.item_count` resolve correctly. Not feature-flagged.

## Deployment Plan

Standard CI/CD — image published from the merge commit, ArgoCD picks it up.

## Rollback Plan

Revert this PR, or roll back to the previous image tag in ArgoGitops.

## Post-Release Support Plan

None.